### PR TITLE
skip running tests by default

### DIFF
--- a/bin/nzm.ts
+++ b/bin/nzm.ts
@@ -32,7 +32,7 @@ async function main() {
     .option('test', {
       type: 'boolean',
       desc: 'Run tests as part of build',
-      default: true,
+      default: false,
     })
     .option('cache', {
       type: 'boolean',


### PR DESCRIPTION
Running tests is expensive during cache misses. Skip tests unless
explicitly asked for.

The standard workflow is to use nozem to bootstrap the lerna dependency
subtree of the concerned package.
Once bootstrapped, the standard npm scripts (`npm run build`,
`npm run test`, etc.) can be used during the dev-test cycle.

There is no need to run the tests, by default, during this bootstrap
phase.